### PR TITLE
Secure secrets via env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ audit_log.txt
 
 node_modules/
 bin
+.env
+.env.*
 
 # sbt specific
 dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: java-static-analysis
+        name: Java static analysis
+        entry: ./scripts/run-static-analysis.sh
+        language: script
+        pass_filenames: false

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -28,7 +28,11 @@ To run everything:
 docker compose up -d --build
 ```
 
-The backend application is available at http://localhost:8080 and the postgres database is exposed on port 5432 with username and password `postgres`.
+First copy `.env.example` to `.env` and set values for `POSTGRES_USER`,
+`POSTGRES_PASSWORD`, `FLASK_SECRET_KEY`, and `LOCAL_WRAPPING_KEY`. After starting
+Docker, the backend application will be available at
+http://localhost:8080 and the postgres database will be exposed on port 5432
+using the credentials you configured.
 
 When you're finished, tear it down with `docker compose down`.
  

--- a/direct-file/.env.example
+++ b/direct-file/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=change_me
+FLASK_SECRET_KEY=replace_me
+LOCAL_WRAPPING_KEY=replace_me

--- a/direct-file/README.md
+++ b/direct-file/README.md
@@ -21,6 +21,9 @@ From the docker desktop:
 
 ## Important configuration variables
 
+Copy `.env.example` to `.env` and set `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+`FLASK_SECRET_KEY`, and `LOCAL_WRAPPING_KEY` before running `docker compose`.
+
 | Name                    | Required | Default        | Description                                                                                                                             |
 |-------------------------|----------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | `DF_DB_USER_ID`         | No       | 999            | User id used to run the database (if you set this, it likely will be to the value of `id -u`.                                           |
@@ -123,6 +126,9 @@ brew install pre-commit
 pre-commit install
 pre-commit install --hook-type pre-push
 ```
+
+The hook executes `scripts/run-static-analysis.sh`, which enforces formatting
+with Spotless and runs SpotBugs and PMD for every Java module.
 
 If you want to disable the checks, you can use:
 

--- a/direct-file/docker-compose.yaml
+++ b/direct-file/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
     entrypoint: "/bin/bash"
     command: -c "chown -R ${DF_DB_USER_ID:-999}:${DF_DB_GROUP_ID:-999} /var/lib/postgresql/data & exec /usr/local/bin/docker-entrypoint.sh postgres"
     environment: &dbuser
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8"
     volumes:
       - "./docker/db/postgres/init:/docker-entrypoint-initdb.d:ro"
@@ -83,7 +83,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       JAVA_TOOL_OPTIONS: "${JAVA_TOOL_OPTIONS:-}"
       OTEL_SERVICE_NAME: "direct-file-api"
-      LOCAL_WRAPPING_KEY: "${LOCAL_WRAPPING_KEY:-oE3Pm+fr1I+YbX2ZxEe/n9INqJjy00KSl7oXXW4p5Xw=}"
+      LOCAL_WRAPPING_KEY: ${LOCAL_WRAPPING_KEY}
       DF_SUBMIT_PORT: "${DF_SUBMIT_PORT:-8083}"
       GIT_COMMIT_HASH: "${GIT_COMMIT_HASH:-}"
       DF_TIN_VALIDATION_ENABLED: ${DF_TIN_VALIDATION_ENABLED:-true}
@@ -111,7 +111,7 @@ services:
       context: ./utils/csp-simulator
     environment:
       FLASK_RUN_HOST: "0.0.0.0"
-      FLASK_SECRET_KEY: "not-so-secret-secret-key"
+      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
       CSPSIM_BACKEND_BASE_URL: "http://host.docker.internal:${DF_API_PORT:-8080}"
       CSPSIM_BACKEND_BASE_PATH: "${DF_API_PUBLIC_PATH:-/df/file/api}"
       CSPSIM_CLIENT_BASE_URL: "http://host.docker.internal:${DF_FE_PORT:-3000}"
@@ -168,7 +168,7 @@ services:
       SMTP_USERNAME: "${SMTP_USERNAME:-}"
       SMTP_PASSWORD: "${SMTP_PASSWORD:-}"
       SPRING_PROFILES_ACTIVE: docker,blackhole
-      LOCAL_WRAPPING_KEY: "${LOCAL_WRAPPING_KEY:-oE3Pm+fr1I+YbX2ZxEe/n9INqJjy00KSl7oXXW4p5Xw=}"
+      LOCAL_WRAPPING_KEY: ${LOCAL_WRAPPING_KEY}
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       JAVA_TOOL_OPTIONS: "${JAVA_TOOL_OPTIONS:-}"
       OTEL_SERVICE_NAME: "direct-file-email"
@@ -195,7 +195,7 @@ services:
         MAVEN_OPTS: "${MAVEN_OPTS:-}"
     read_only: true
     environment:
-      LOCAL_WRAPPING_KEY: "${LOCAL_WRAPPING_KEY:-oE3Pm+fr1I+YbX2ZxEe/n9INqJjy00KSl7oXXW4p5Xw=}"
+      LOCAL_WRAPPING_KEY: ${LOCAL_WRAPPING_KEY}
       SPRING_PROFILES_ACTIVE: development,docker
       STATEAPI_PORT: "${STATEAPI_PORT:-8081}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"

--- a/direct-file/state-api/README.md
+++ b/direct-file/state-api/README.md
@@ -24,7 +24,9 @@ To quickly set up the application and run the supporting services (localstack, d
 docker compose up state-api -d
 ```
 
-The `state-api` application will be accessible at http://localhost:8081, and the PostgreSQL database will be available on port 5433 with the default username and password `postgres`.
+The `state-api` application will be accessible at http://localhost:8081.
+Database credentials are provided via environment variables `POSTGRES_USER` and
+`POSTGRES_PASSWORD` from your `.env` file.
 
 Health check: http://localhost:8081/actuator/health
 Swagger API:  http://localhost:8081/swagger-ui/index.html

--- a/direct-file/status/Dockerfile-local
+++ b/direct-file/status/Dockerfile-local
@@ -44,7 +44,7 @@ COPY src/ src/
 RUN ./mvnw package
 
 FROM eclipse-temurin:21-jre-alpine
-ENV LOCAL_WRAPPING_KEY "${LOCAL_WRAPPING_KEY:-oE3Pm+fr1I+YbX2ZxEe/n9INqJjy00KSl7oXXW4p5Xw=}"
+ENV LOCAL_WRAPPING_KEY "${LOCAL_WRAPPING_KEY}"
 COPY --from=mef-status-builder /build/target/mef-status-0.0.1-SNAPSHOT.jar /app.jar
 COPY --from=mef-sdk-repo MeF_Client_SDK/Java/source/ /mef-client-sdk-src/
 # Run from dir that allows mef-sdk to write it's files to the working directory (next iteration: configure mef-sdk)

--- a/direct-file/submit/src/main/resources/application-docker.yaml
+++ b/direct-file/submit/src/main/resources/application-docker.yaml
@@ -28,4 +28,4 @@ submit:
 # these defaults are to match the backend (update/remove once we're fully onto sqs)
 direct-file:
   local-encryption:
-    local-wrapping-key: ${LOCAL_WRAPPING_KEY:oE3Pm+fr1I+YbX2ZxEe/n9INqJjy00KSl7oXXW4p5Xw=}
+    local-wrapping-key: ${LOCAL_WRAPPING_KEY}

--- a/scripts/run-static-analysis.sh
+++ b/scripts/run-static-analysis.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Runs formatting and static analysis checks for all Java modules
+set -euo pipefail
+modules=(backend submit status state-api email-service)
+for module in "${modules[@]}"; do
+  if [ -d "direct-file/${module}" ]; then
+    echo "[pre-commit] Running checks for ${module}"
+    (cd "direct-file/${module}" && ./mvnw spotless:check compile spotbugs:check pmd:check)
+  fi
+done


### PR DESCRIPTION
## Summary
- make docker-compose credentials read from environment variables
- ignore local `.env` files
- document environment variable setup and provide `.env.example`
- update docs and defaults per feedback
- add pre-commit config that runs static analysis on Java modules
- explain `.env` in Onboarding and update state-api docs

## Testing
- `pre-commit run --files ONBOARDING.md direct-file/state-api/README.md` *(fails: command not found)*
- `(cd direct-file/backend && ./mvnw -q -DskipTests install)` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845b8163e1c832abc3700a14d4b2552